### PR TITLE
chore: This adds in the licenses for our fork

### DIFF
--- a/PATCH_LICENSE.txt
+++ b/PATCH_LICENSE.txt
@@ -1,0 +1,98 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             The Liquid Foundation
+
+Licensed Work:        Liquid Collective Stake Pool
+                      The Licensed Work is (c) 2025 The Liquid Foundation
+
+Additional Use Grant: Not applicable
+
+Change Date:          1 June 2029 
+
+Change License:       Apache License, Version 2.0
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Python bindings are available in the `./py` directory.
 
 The repository [README](https://github.com/solana-labs/solana-program-library#audits)
 contains information about program audits.
+
+## Notice regarding this fork 
+
+The [Liquid Collective Stake Pool](https://github.com/liquid-collective/liquid-collective-solana) uses a fork of the SPL Stake Pool program to permission the stake-pool and allow freezable tokens.
+
+The stake-pool is licensed under the Apache License, Version 2.0. You may obtain a copy of that license at http://www.apache.org/licenses/LICENSE-2.0
+
+Changes to stake-pool are subject to the license described in [PATCH_LICENSE.txt](./PATCH_LICENSE.txt).

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,4 +1,6 @@
 //! Instruction types
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 // Remove the following `allow` when `Redelegate` is removed, required to avoid
 // warnings from uses of deprecated types during trait derivations.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(missing_docs)]
 
 //! A program for creating and managing pools of stake
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 pub mod big_vec;
 pub mod error;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,4 +1,6 @@
 //! Program state processor
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 use {
     crate::{

--- a/program/tests/helpers/mod.rs
+++ b/program/tests/helpers/mod.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 use {
     borsh::BorshDeserialize,

--- a/program/tests/huge_pool.rs
+++ b/program/tests/huge_pool.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 

--- a/program/tests/initialize.rs
+++ b/program/tests/initialize.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::items_after_test_module)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 

--- a/program/tests/vsa_remove.rs
+++ b/program/tests/vsa_remove.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 

--- a/program/tests/withdraw_edge_cases.rs
+++ b/program/tests/withdraw_edge_cases.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::items_after_test_module)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 

--- a/program/tests/withdraw_with_fee.rs
+++ b/program/tests/withdraw_with_fee.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg(feature = "test-sbf")]
+// Modified by Alluvial Finance, Inc. for Liquid Collective on 25-02-2025
+// Changes: Permissioning the stake-pool and allowing freezable tokens
 
 mod helpers;
 


### PR DESCRIPTION
This pull request introduces licensing updates and modifications to the stake-pool program for the Liquid Collective. The most significant changes include the addition of a new license file, updates to the `README.md` to reflect licensing and fork details, and code changes to implement permissioning and freezable tokens in the stake-pool.

### Licensing Updates:
* Added a `PATCH_LICENSE.txt` file containing the Business Source License 1.1, with details about the licensing terms, change date, and transition to the Apache License, Version 2.0.
* Updated `README.md` to include a notice about the forked stake-pool, its licensing under the Apache License, and a reference to the `PATCH_LICENSE.txt` file.

### Stake-Pool Modifications:
* Added comments in `program/src/instruction.rs`, `program/src/lib.rs`, `program/src/processor.rs`, and multiple test files to document changes made by Alluvial Finance, Inc. for the Liquid Collective. These changes include permissioning the stake-pool and enabling freezable tokens. [[1]](diffhunk://#diff-6a9607b3f62ff6bd2de50d4ae60d001d9ec67235c580c8dcdf6165e662313d6aR2-R3) [[2]](diffhunk://#diff-e1296dff7fbf2b6468683afa45996e5d84c9dc1e81175710ee462b3c84723b80R4-R5) [[3]](diffhunk://#diff-6c0532d30478a359d78b7b347b1a852750ec83307e3edd4bcdc2a0edbc02d17fR2-R3) [[4]](diffhunk://#diff-99304aae5aa42911f535262654fe498915a0004ce5f0d1d30d1164d7d8088120R2-R3) [[5]](diffhunk://#diff-e4b8a44948647ac5267d408e14eb51accd5eb8e08658746e0f59cedf80c92d8eR3-R4) [[6]](diffhunk://#diff-cf585f1bbf279021c2c3cd72ed4d67d6838cc43c2218cf04a24856cc25665cfbR4-R5) [[7]](diffhunk://#diff-1c843fff88d063de1495e856d0c71e59a6659fe4b11b0b00d6f4f1a116f21dd9R3-R4) [[8]](diffhunk://#diff-90d543e5299be50575e43f02b2a492a02a345dbc8621a7e3637db24c798d3b6eR3-R4) [[9]](diffhunk://#diff-93a25fb0ddc883c08e92eec362adc883fb4ba045af30b19f7aec7f48f23b310dR4-R5) [[10]](diffhunk://#diff-6876185780a205b7e71d9c63ecfc849bc98ba4ce24744537465118a15a9c72dcR3-R4)