### PR TITLE
chore: update build command from cargo build-sbf to pnpm programs:build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The stake-pool is licensed under the Apache License, Version 2.0. You may obtain
 Changes to stake-pool are subject to the license described in [PATCH_LICENSE.txt](./PATCH_LICENSE.txt).
 
 ## Deployment
-Inside the root directory:
+Inside the project root directory:
 
 First we need to build the program:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The stake-pool is licensed under the Apache License, Version 2.0. You may obtain
 Changes to stake-pool are subject to the license described in [PATCH_LICENSE.txt](./PATCH_LICENSE.txt).
 
 ## Deployment
-Inside the `program` directory:
+Inside the root directory:
 
 First we need to build the program:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Inside the `program` directory:
 First we need to build the program:
 
 ```bash
-cargo build-sbf
+pnpm programs:build
 ```
 
 Then we can run the `solana program deploy` command:


### PR DESCRIPTION
This pull request updates the build instructions in the `README.md` to reflect a change in the recommended build tool for the `program` directory.

Documentation update:

* Replaced the `cargo build-sbf` command with `pnpm programs:build` in the build instructions for the `program` directory in `README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README Deployment section to reference the project root directory.
  * Replaced the previous build command with the new build command in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->