### PR TITLE
chore(ci): use the current default branch for workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches: ["liquid_collective_release/v2.0.0"]
   pull_request:
-    branches: [main]
+    branches: ["liquid_collective_release/v2.0.0"]
 
 jobs:
   format_and_lint_programs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to trigger on a specific release branch for push and pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->